### PR TITLE
Fixed the right align in the navbar

### DIFF
--- a/FinTeach/src/app/navbar/navbar.component.html
+++ b/FinTeach/src/app/navbar/navbar.component.html
@@ -42,8 +42,7 @@
           </button>
       </div>
   </div>
-  <div style="
-  margin-left: 900px"class="collapse navbar-collapse flex-grow-1 text-right" id="myNavbar">
+  <div class="collapse navbar-collapse justify-content-end flex-grow-1 text-right" id="myNavbar">
       <ul class="navbar-nav ml-auto flex-nowrap">
           <li class="nav-item">
               <a style="font-weight:bold" routerLink="/modules" class="nav-link m-2 menu-item nav-active">Modules</a>


### PR DESCRIPTION
When the margin was hardcoded, the stuff on the right went off my screen.
![image](https://user-images.githubusercontent.com/78986301/140662194-e4a08d65-05cc-42d2-bf07-2518ffad056b.png)
![image](https://user-images.githubusercontent.com/78986301/140662206-99a25448-2f76-49f0-b430-5d2340b80cf9.png)

I think this fixes that issue.
